### PR TITLE
Updated docs with miniconda alternative

### DIFF
--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -20,7 +20,9 @@ requirements:
    ``xslt-config`` to see.
 
 Consult your operating system instructions or system administrator to install
-the required packages.
+the required packages. For those without system administrator access and are 
+feeling anxious, you could try a local (home directory) Python_ 3 installation 
+using a Miniconda_ installation.
 
 
 Doing the Installation
@@ -73,3 +75,4 @@ virtual environment::
 .. _`virtual environment`: https://docs.python.org/3/library/venv.html
 .. _Buildout: http://www.buildout.org/
 .. _Cheeseshop: https://pypi.org/
+.. _Miniconda: https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html


### PR DESCRIPTION
Tested installation successfully on linux machine:

* Installed miniconda using bash script from Miniconda install guide, then

```
(base) [jpadams@pds-gamma ~]$ which python3
~/miniconda3/bin/python3
(base) [jpadams@pds-gamma ~]$ xml2-config --version
2.9.8
(base) [jpadams@pds-gamma ~]$ python3 -m venv $HOME/.virtualenvs/test
(base) [jpadams@pds-gamma ~]$ source /home/jpadams/.virtualenvs/test/bin/activate
(test) (base) [jpadams@pds-gamma ~]$ pip3 install pds.deeparchive

...

(test) (base) [jpadams@pds-gamma ~]$ pds-deep-archive -b https://foo.com -s PDS_NAI /data/pds4/urn-nasa-pds-mess_rs_derived/bundle_mess_rs_derived.xml
INFO ð PDS Deep Archive, version 0.1.0
INFO ð‍♀️ Starting AIP generation for /data/pds4/urn-nasa-pds-mess_rs_derived/bundle_mess_rs_derived.xml
INFO ð  Success! AIP done, files generated:
INFO • Checksum manifest: mess_rs_derived_v1.0_checksum_manifest_v1.0.tab
INFO • Transfer manifest: mess_rs_derived_v1.0_transfer_manifest_v1.0.tab
INFO • XML label for them both: mess_rs_derived_v1.0_aip_v1.0.xml
WARNING ð Notice! --include-all-collections isn't yet supported; will assume it's enabled for now
INFO ð‍♀️ Starting SIP generation for /data/pds4/urn-nasa-pds-mess_rs_derived/bundle_mess_rs_derived.xml
INFO ð Success! From /data/pds4/urn-nasa-pds-mess_rs_derived/bundle_mess_rs_derived.xml, generated these output files:
INFO • SIP Manifest: mess_rs_derived_v1.0_sip_v1.0.tab
INFO • XML label for the SIP: mess_rs_derived_v1.0_sip_v1.0.xml
INFO ð That's it! Thanks for making an AIP and SIP with us today. Bye!
```

Resolves #61 