### PR TITLE
Resolve #69 🎉

### DIFF
--- a/src/pds/aipgen/constants.py
+++ b/src/pds/aipgen/constants.py
@@ -40,6 +40,9 @@ INFORMATION_MODEL_VERSION = '1.13.0.0'
 # Namespace URI for PDS XML
 PDS_NS_URI = 'http://pds.nasa.gov/pds4/pds/v1'
 
+# XML tag for a PDS product collection
+PRODUCT_COLLECTION_TAG = f'{{{PDS_NS_URI}}}Product_Collection'
+
 # Where to find the PDS schema
 PDS_SCHEMA_URL = 'http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1D00.xsd'
 


### PR DESCRIPTION
## Summary 📈

This will resolve #69 by making it so that:

- We no longer assume that any `<file_name>`s with `.tab` files mentioned contain tables of additional primaries 💢
- But we but do assume that all `<file_name>`s that are in `<Product_Collection>`s do 👍


## Test Data 🩺

```csh
fatalii 272 % date -u
Fri Jun 26 23:19:09 UTC 2020
fatalii 273 % bin/test
Running tests at level 1
Running zope.testrunner.layer.UnitTests tests:
  Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
  Running:
    4/7 (57.1%) test_logging_arguments (pds.aipgen.tests.test_utils.ArgumentTestCase)usage: 
                                                                                          
  Ran 7 tests with 0 failures, 0 errors, 0 skipped in 0.078 seconds.
Tearing down left over layers:
  Tear down zope.testrunner.layer.UnitTests in 0.000 seconds.
fatalii 274 % echo woot \U+1F38A
woot 🎊
fatalii 275 % 
```

## Related Issues 🌡

Resolves #69 
