### PR TITLE
Resolve #77 and #78

### DIFF
--- a/src/pds/aipgen/main.py
+++ b/src/pds/aipgen/main.py
@@ -38,7 +38,7 @@ from .sip import addSIParguments
 from .sip import produce as sipProcess
 from .utils import addLoggingArguments, addBundleArguments, createSchema, comprehendDirectory
 from datetime import datetime
-import argparse, sys, logging, tempfile, sqlite3, os
+import argparse, sys, logging, tempfile, sqlite3, os, shutil
 
 
 # Constants
@@ -91,10 +91,12 @@ def main():
     logging.basicConfig(level=args.loglevel, format='%(levelname)s %(message)s')
     _logger.info('👟 PDS Deep Archive, version %s', __version__)
     _logger.debug('⚙️ command line args = %r', args)
-    with tempfile.NamedTemporaryFile() as dbfile:
+    tempdir = tempfile.mkdtemp(suffix='.dir', prefix='deep')
+    try:
         # Make a site survey
-        con = sqlite3.connect(dbfile.name)
-        _logger.debug('⚙️ Creating potentially future-mulitprocessing–capable DB in %s', dbfile.name)
+        dbfile = os.path.join(tempdir, 'pds-deep-archive.sqlite3')
+        con = sqlite3.connect(dbfile)
+        _logger.debug('⚙️ Creating potentially future-mulitprocessing–capable DB in %s', dbfile)
         with con:
             createSchema(con)
             comprehendDirectory(os.path.dirname(os.path.abspath(args.bundle.name)), con)
@@ -122,6 +124,8 @@ def main():
                 con,
                 ts
             )
+    finally:
+        shutil.rmtree(tempdir, ignore_errors=True)
     _logger.info("👋 That's it! Thanks for making an AIP and SIP with us today. Bye!")
     sys.exit(0)
 


### PR DESCRIPTION
Use a temp dir instead of an unlinked temp file and fix arg to calling process on aipgen

## Summary

Previously, we were using `NamedTemporaryFile` to make a temporary file for `sqlite3`. `sqlite3` would close and open this file several times during processing. On Unix, this is fine. On Windows NT or later, the very first "close" on the file would render it unusable by future opens. So instead, we make a temporary _directory_ instead of a file and use a known filename inside of that (#77).

Also, we noticed that there was a redundant `args.` being referenced in the call to `process` in `aip.py`. This fixes that (#78).

## Test Data and/or Report

```console
Running tests at level 1
Running zope.testrunner.layer.UnitTests tests:
  Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
  Running:
    10/13 (76.9%) test_logging_arguments (pds.aipgen.tests.test_utils.ArgumentTestCase)usage: 
                                                                                            
  Ran 13 tests with 0 failures, 0 errors, 0 skipped in 0.763 seconds.
Tearing down left over layers:
  Tear down zope.testrunner.layer.UnitTests in 0.000 seconds.
```

## Related Issues

- #77 
- #78 

