### PR TITLE
Resolve #82: standardize on Unix path sep during bundle comprehension

### DIFF
--- a/src/pds/aipgen/utils.py
+++ b/src/pds/aipgen/utils.py
@@ -129,7 +129,7 @@ def comprehendDirectory(dn, con):
                     con.execute('INSERT OR IGNORE INTO labels (lid, vid) VALUES (?, ?)', (lid, vid))
                     con.execute(
                         'INSERT OR IGNORE INTO label_file_references (lid, vid, filepath) VALUES (?,?,?)',
-                        (lid, vid, xmlFile)
+                        (lid, vid, xmlFile.replace('\\', '/'))
                     )
 
                     # Now see if it refers to other XML files
@@ -164,7 +164,7 @@ def comprehendDirectory(dn, con):
                         if os.path.isfile(filepath):
                             con.execute(
                                 'INSERT OR IGNORE INTO label_file_references (lid, vid, filepath) VALUES (?,?,?)',
-                                (lid, vid, filepath)
+                                (lid, vid, filepath.replace('\\', '/'))
                             )
                             # Weird (to a certain degree of weird) case: <file_name> may refer to a file
                             # that contains even more inter_label_references, but only if this label is


### PR DESCRIPTION
## 📜 Summary

During the comprehension step, platform-native paths were recorded in the database built to model the important relationships and parts of the bundle. Those platform-native paths were then used "as-is" in URL construction and other contexts, which broke on Windows which uses a path separator different from URLs, etc.

## 🔬 Test Data

```console
Running tests at level 1
Running zope.testrunner.layer.UnitTests tests:
  Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
  Running:
    10/13 (76.9%) test_logging_arguments (pds.aipgen.tests.test_utils.ArgumentTestCase)usage: 
                                                                                            
  Ran 13 tests with 0 failures, 0 errors, 0 skipped in 0.714 seconds.
Tearing down left over layers:
  Tear down zope.testrunner.layer.UnitTests in 0.000 seconds.
```

## 🧬 Related Issues

- #82 
