### PR TITLE
Resolve #87: log but don't otherwise try to parse bad XML

### DIFF
--- a/src/pds/aipgen/utils.py
+++ b/src/pds/aipgen/utils.py
@@ -122,6 +122,7 @@ def comprehendDirectory(dn, con):
                 xmlFile = os.path.join(dirpath, fn)
                 _logger.debug('📄 Deconstructing %s', xmlFile)
                 tree = parseXML(xmlFile)
+                if tree is None: continue
                 isProductCollection = tree.getroot().tag == PRODUCT_COLLECTION_TAG
                 lid, vid = getLogicalVersionIdentifier(tree)
                 if lid and vid:
@@ -178,7 +179,11 @@ def comprehendDirectory(dn, con):
 @functools.lru_cache(maxsize=_xmlCacheSize)
 def parseXML(f):
     '''Parse the XML in object ``f``'''
-    return etree.parse(f)
+    try:
+        return etree.parse(f)
+    except etree.XMLSyntaxError:
+        _logger.warning('👀 Cannot parse XML document at «%s»; ignoring it', f)
+        return None
 
 
 @functools.lru_cache(maxsize=_digestCacheSize)


### PR DESCRIPTION
## 📜 Summary

Merge this (if you dare) and instead of bombing out on parsing empty XML files (or any bad XML file) we instead just log a warning message and press on. This should work around Gary's empty `._bundle.xml` files in #87.

## 🩺 Test Data and/or Report

In this merge we add a file called `empty.xml` so the unit and functional testing can ensure we work with empty XML files. Test report:

```console
$ bin/test
Running tests at level 1
Running zope.testrunner.layer.UnitTests tests:
  Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
  Running:
    10/13 (76.9%) test_logging_arguments (pds.aipgen.tests.test_utils.ArgumentTestCase)usage: 
                                                                                            
  Ran 13 tests with 0 failures, 0 errors, 0 skipped in 0.653 seconds.
Tearing down left over layers:
  Tear down zope.testrunner.layer.UnitTests in 0.000 seconds.
```

## 👨‍👩‍👦 Related Issues

- See #87 