### PR TITLE
Resolve #95

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,11 +31,16 @@ You should then be able to run the deep archive utilities::
     (pds-deep-archive) bash> aipgen --help
     (pds-deep-archive) bash> sipgen --help
 
+.. note:: The above commands demonstrate typical usage with a command-line
+    prompt, such as that provided by the popular ``bash`` shell; your own
+    prompt may appear differently and may vary depending on operating system,
+    shell choice, and so forth.
+
 
 Build
 =====
 
-See the Development_Guide_ for more information.
+See the `Development Guide`_ for more information.
 
 
 Documentation
@@ -81,7 +86,7 @@ LICENSE.txt file for details.
 .. _virtualenv: https://docs.python.org/3/library/venv.html
 .. _lxml: https://lxml.de/
 .. _Installation: https://nasa-pds.github.io/pds-deep-archive/installation/
-.. _Development_Guide: https://nasa-pds.github.io/pds-deep-archive/development/
+.. _`Development Guide`: https://nasa-pds.github.io/pds-deep-archive/development/
 
 .. |Unstable Build| image:: https://github.com/NASA-PDS/pds-deep-archive/workflows/%F0%9F%A4%AA%20Unstable%20integration%20&%20delivery/badge.svg
    :target: https://github.com/NASA-PDS/pds-deep-archive/actions?query=workflow%3A%22%F0%9F%A4%AA+Unstable+integration+%26+delivery%22

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -9,6 +9,11 @@ build it out::
     python3 bootstrap.py
     bin/buildout
 
+.. note:: The above series of commands assume you have the corresponding
+    development tools and familiarity with invoking them from the
+    command line or "terminal". Shells, operating systems, and command
+    invocation varies.
+
 At this point, you'll have the ``pds-deep-archive``, ``aipgen``, ``sipgen``
 programs ready to run as ``bin/pds-deep-archive``, ``bin/aipgen``, and
 ``bin/sipgen`` that's set up to use source Python code under ``src``.
@@ -80,6 +85,8 @@ To deploy to the official PyPi manually:
     pip install twine
     twine upload dist/*.tar.gz
 
+.. note:: The same admonitions mentioned earlier about command line
+    invocations also apply to the above example.
 
 Contribute
 ----------

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -42,7 +42,7 @@ you can run ``pip3 --help`` to check.
 It's best install the PDS Deep Archive into a `virtual environment`_ so it
 won't interfere with—or be interfered by—other packages.  To do so::
 
-    # For Linux / Mac
+    # For Linux / Mac / other Unix systems
     mkdir -p $HOME/.virtualenvs
     python3 -m venv $HOME/.virtualenvs/pds-deep-archive
     source $HOME/.virtualenvs/pds-deep-archive/bin/activate
@@ -53,6 +53,13 @@ won't interfere with—or be interfered by—other packages.  To do so::
     python -m venv virtualenvs\\pds-deep-archive
     virtualenvs\\pds-deep-archive\\Scripts\\activate
     pip3 install pds.deeparchive
+
+.. note:: The octothorp characters `#` above indicate comments and need not be
+    typed in. The location of where you choose to create a Python virtual
+    environment is entirely your preference; the above should be seen only as
+    suggestions. Invoking command lines above are demonstrative; please consult
+    your system documentation for the appropriate invocations for your operating
+    system, command shell (or "terminal"), and so forth.
 
 It's also possible to use ``easy_install`` if you prefer, or to install it
 via a Buildout_, or (if you must) into the system Python.
@@ -82,8 +89,12 @@ Upgrade Software
 To check and install an upgrade to the software, run the following command in your 
 virtual environment::
 
-  source $HOME/.virtualenvs/pds-deep-archive/bin/activate
-  pip install pds.deeparchive --upgrade
+    source $HOME/.virtualenvs/pds-deep-archive/bin/activate
+    pip install pds.deeparchive --upgrade
+
+.. note:: The same admonitions mentioned earlier about command line
+    invocations also apply to the above example.
+
 
 
 .. References:

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -36,19 +36,43 @@ Example 1: Basic Usage
 For example, to create a SIP and AIP from the LADEE 1101 Bundle located at
 ``test/data/ladee_test/mission_bundle/LADEE_Bundle_1101.xml`` run the
 following (NOTE: assumes you followed the default Installation into a Virtual
-Environment)::
+Environment); note that lines starting with the octothorp ``#`` are comments
+to help explain what follows and need not be typed in::
 
     # Prep your environment by sourcing your Python virtual environment
     $ source $HOME/.virtualenvs/pds-deep-archive/bin/activate
 
+.. note:: The ``source`` command and the location of your Python virtual
+    environment may vary depending on the command-line interpreter (terminal)
+    you're using and the installation of Python. You may wish to consult a
+    system administrator for clarification. In some cases, it may involve
+    simply replacing ``source`` with a single period ``.``; in others, it
+    may be more involved, especially the location of your Python virtual
+    environment.
+
+::
+
     # The (pds-deep-archive) prefix indicates your virtual environment is active
     (pds-deep-archive) $
+
+.. note:: The changes the the prompt may not necessarily appear depending on
+    the local machine environment, command interpreter, etc.
+
+::
 
     # Now let's run pds-deep-archive
     # NOTE: This software must be run against data on your local filesystem
     (pds-deep-archive) $ pds-deep-archive -s PDS_ATM  \ 
-                            -b https://atmos.nmsu.edu/PDS/data/PDS4/LADEE/  \
-                            test/data/ladee_test/mission_bundle/LADEE_Bundle_1101.xml
+        -b https://atmos.nmsu.edu/PDS/data/PDS4/LADEE/  \
+        test/data/ladee_test/mission_bundle/LADEE_Bundle_1101.xml
+
+.. note:: The trailing backslashes above are "continuation characters" to
+    indicate to the command shell that the entire command line spans multiple
+    physical lines. You may choose to enter the command on a single long
+    physical line without the backslashes. Regardless, please consult your
+    documentation regarding what the proper continuation character is for
+    your shell; in the most common cases, it is a backslash.
+
 
 From this command-line execution, we are inputting the following information:
 
@@ -113,9 +137,12 @@ This is the default functionality of ``pds-deep-archive``. See `Example 1: Basic
 Execute the software with the ``--include-latest-collection-only`` flag enabled, for example::
 
     (pds-deep-archive) $ pds-deep-archive -s PDS_ATM  \ 
-                            -b https://atmos.nmsu.edu/PDS/data/PDS4/LADEE/  \
-                            test/data/ladee_test/mission_bundle/LADEE_Bundle_1101.xml
-                            --include-latest-collection-only
+        -b https://atmos.nmsu.edu/PDS/data/PDS4/LADEE/  \
+        test/data/ladee_test/mission_bundle/LADEE_Bundle_1101.xml
+        --include-latest-collection-only
+
+.. note:: The same admonitions about the command prompt and continuation
+    characters mentioned earlier applies to the above example.
 
 
 PDS Delivery Checklist
@@ -138,7 +165,7 @@ For more formalized details on the NSSDCA Delivery Process, see the following `p
         # Example of a bad URL
         https://this.url.does.not.exist.com/LADEE_Bundle_1101.xml
 
-        # Example of  GOOD URL (file exists online)
+        # Example of GOOD URL (file exists online)
         https://atmos.nmsu.edu/PDS/data/PDS4/LADEE/mission_bundle/LADEE_Bundle_1101.xml
 
 5.     Package up the five ``*.tab` and ``*.xml`` files into a ``.ZIP`` or ``.TAR.GZ`` PDS Deep Archive Delivery package. For example::


### PR DESCRIPTION
## 📖 Summary

This implements a number of updates to the Deep Archive documentation by providing highlighted notes, warning, admonitions, etc., to indicate command-line examples and variances.

## 🩺 Test Data and/or Report

```console
Running tests at level 1
Running zope.testrunner.layer.UnitTests tests:
  Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
  Running:
    13/16 (81.2%) test_logging_arguments (pds.aipgen.tests.test_utils.ArgumentTestCase)usage: 
                                                                                            
  Ran 16 tests with 0 failures, 0 errors, 0 skipped in 0.625 seconds.
Tearing down left over layers:
  Tear down zope.testrunner.layer.UnitTests in 0.000 seconds.
```

## 🧩 Related Issues

- #95 
