### PR TITLE
Resolve #93: add `year` to manifest URL

### DIFF
--- a/src/pds/aipgen/sip.py
+++ b/src/pds/aipgen/sip.py
@@ -213,7 +213,7 @@ def _writeLabel(
     deep.append(etree.Comment('MD5 digest checksum for the manifest file'))
     etree.SubElement(deep, prefix + 'manifest_checksum').text = digest
     etree.SubElement(deep, prefix + 'checksum_type').text = 'MD5'
-    etree.SubElement(deep, prefix + 'manifest_url').text = SIP_MANIFEST_URL + manifestFile
+    etree.SubElement(deep, prefix + 'manifest_url').text = SIP_MANIFEST_URL + str(timestamp.year) + '/' + manifestFile
     etree.SubElement(deep, prefix + 'aip_lidvid').text = AIP_PRODUCT_URI_PREFIX + logicalID.split(':')[-1] + '_v' + versionID + '_' + timestamp.date().strftime('%Y%m%d') + '::1.0'
 
     aipMD5 = getMD5(aipFile) if aipFile else '00000000000000000000000000000000'

--- a/src/pds/aipgen/tests/base.py
+++ b/src/pds/aipgen/tests/base.py
@@ -32,7 +32,7 @@
 '''PDS AIP-GEN test base classes'''
 
 
-from datetime import datetime
+from datetime import datetime, date
 from lxml import etree
 from pds.aipgen.aip import process as produce_aip
 from pds.aipgen.constants import PDS_NS_URI
@@ -123,7 +123,14 @@ class SIPFunctionalTestCase(_FunctionalTestCase):
         )
         matches = etree.parse(label).getroot().findall(self._urlXPath)
         self.assertEqual(1, len(matches))
-        self.assertTrue(matches[0].text.startswith('https://pds.nasa.gov/data/pds4/manifests/'))
+        url = matches[0].text
+        self.assertTrue(url.startswith('https://pds.nasa.gov/data/pds4/manifests/'))
+        # https://github.com/NASA-PDS/pds-deep-archive/issues/93
+        currentYear = date.today().year
+        # Account for the possibility that it's "Happy New Year 🍾" between label generation and testing
+        legalYears = str(currentYear), str(currentYear + 1)
+        urlEnd = url.split('/')[-2]
+        self.assertTrue(urlEnd in legalYears, f"Expected {url} to contain either {legalYears} but didn't")
 
 
 class AIPFunctionalTestCase(_FunctionalTestCase):


### PR DESCRIPTION
## 📖 Summary

Merge this and you get:

- An update to a base test case that checks of the manifest URL of a SIP's label has the current year in it
- SIP label generation that includes the year in the manifest URL

## 🩺 Test Data and/or Report

```console
Running tests at level 1
Running zope.testrunner.layer.UnitTests tests:
  Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
  Running:
    13/16 (81.2%) test_logging_arguments (pds.aipgen.tests.test_utils.ArgumentTestCase)usage: 
                                                                                            
  Ran 16 tests with 0 failures, 0 errors, 0 skipped in 0.521 seconds.
Tearing down left over layers:
  Tear down zope.testrunner.layer.UnitTests in 0.000 seconds.
```

## 🧩 Related Issues

- #93 
