### PR TITLE
Resolve #99

### DIFF
--- a/src/pds/aipgen/main.py
+++ b/src/pds/aipgen/main.py
@@ -105,8 +105,8 @@ def main():
         ts = datetime.utcnow()
         ts = datetime(ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, microsecond=0, tzinfo=None)
 
-        chksumFN, dummy, dummy = aipProcess(args.bundle, args.include_latest_collection_only, con, ts)
-        with open(chksumFN, 'rb') as chksumStream:
+        dummy, dummy, labelFN = aipProcess(args.bundle, args.include_latest_collection_only, con, ts)
+        with open(labelFN, 'rb') as chksumStream:
             sipProcess(
                 args.bundle,
                 # TODO: Temporarily hardcoding these values until other modes are available


### PR DESCRIPTION
## 📜 Summary

This resolves #99 by putting the checksum¹ of the AIP label XML file into the `<aip_label_checksum>`² element of the SIP label XML file. Previously this was the checksum³ of the AIP checksum⁴ manifest file and the transfer manifest was ignored. Now, both the checksum⁵ manifest and the transfer manifest are ignored and the AIP label gets the checksum⁶ limelight.

## 🩺 Test Data and/or Report

```
fatalii 358 % date -u
Tue Feb 23 17:32:49 UTC 2021
fatalii 359 % sw_vers
ProductName:	macOS
ProductVersion:	11.2.1
BuildVersion:	20D74
fatalii 360 % python3 --version
Python 3.8.6
fatalii 361 % bin/test
Running tests at level 1
Running zope.testrunner.layer.UnitTests tests:
  Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
  Running:
    13/16 (81.2%) test_logging_arguments (pds.aipgen.tests.test_utils.ArgumentTestCase)usage: 
                                                                                            
  Ran 16 tests with 0 failures, 0 errors, 0 skipped in 0.558 seconds.
Tearing down left over layers:
  Tear down zope.testrunner.layer.UnitTests in 0.000 seconds.
fatalii 362 % 
```

## 🧩 Related Issues

- #99 

## 📝 Footnotes

¹Not a checksum, but a hash.
²Also not a checksum.
³Actually a hash.
⁴It's called a checksum manifest, but it contains the output of message digests, which are hashes.
⁵Again, not a checksum.
⁶"Sum" is right in the name, this is is not at all a sum; a message digest's output is a hash⁷.
⁷Yes this is all rather anal-retentive⁸.
⁸What do you mean, you've never seen footnotes in pull requests before? 🧐
